### PR TITLE
The ALP header should jump to the top of the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
 	<div id="menu">
 		<div class="pure-menu">
-			<a class="pure-menu-heading" href="#alp">ALP</a>
+			<a class="pure-menu-heading" href="#top">ALP</a>
 
 			<ul class="pure-menu-list">
 				<li class="pure-menu-item">
@@ -45,7 +45,7 @@
 
 	<div id="main">
 		<div class="header">
-			<h1>Algebraic Programming</h1>
+			<h1 id="top">Algebraic Programming</h1>
 			<h2>Auto-parallelising and auto-optimising frameworks for algebraically expressed codes</h2>
 		</div>
 


### PR DESCRIPTION
The ALP header was jumping to the alp anchor, which corresponds to the C++ ALP project. It should jump to the top of the page instead.